### PR TITLE
feat: Add product by scraping Etsy URL

### DIFF
--- a/backend/routes/productGenerator.js
+++ b/backend/routes/productGenerator.js
@@ -11,164 +11,69 @@ const tasks = new Map();
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const OPENAI_API_BASE = process.env.OPENAI_API_BASE || "https://api.openai.com/v1";
 
-// Product data generation template
-const PRODUCT_TEMPLATE = `
-You are an expert data extractor for e-commerce websites. Your task is to extract product information from the provided scraped content and return it as a valid JSON object.
+// Web scraping function for Etsy product pages
+async function scrapeEtsyProductPage(url) {
+  if (!url.includes('etsy.com')) {
+    throw new Error('This scraper currently only supports Etsy.com URLs.');
+  }
 
-**JSON Object Structure:**
-The JSON object must conform to the following structure. Do not add any extra fields.
-{
-  "name": "String",
-  "description": "String",
-  "price": "Number",
-  "comparePrice": "Number",
-  "category": "String",
-  "subcategory": "String",
-  "brand": "String",
-  "image": "String (URL)",
-  "images": ["String (URL)"],
-  "countInStock": "Number",
-  "rating": "Number (0-5)",
-  "numReviews": "Number",
-  "specifications": { "key": "value" },
-  "tags": ["String"],
-  "sku": "String",
-  "seoTitle": "String",
-  "seoDescription": "String"
-}
-
-**Instructions:**
-1.  **Analyze the scraped content**: Carefully review the HTML content, metadata, and JSON-LD data.
-2.  **Extract data for each field**: Fill in the JSON object with the extracted information.
-3.  **Handle missing data**: If a value is not found, use a reasonable default (e.g., empty string for text, 0 for numbers, empty array for lists). For 'countInStock', if not specified, default to 10.
-4.  **price and comparePrice**: These should be numbers, not strings. Remove currency symbols. If there's only one price, use it for 'price' and leave 'comparePrice' as 0. If there are two prices (e.g., a sale price and an original price), the lower one is 'price' and the higher one is 'comparePrice'.
-5.  **images**: The 'image' field should be the main product image. The 'images' field should be an array of all product image URLs.
-6.  **description**: Provide a detailed and clean product description. Remove any HTML tags.
-7.  **specifications**: Extract key-value pairs of product specifications if available.
-8.  **Output**: Return only the raw JSON object. Do not wrap it in markdown or any other text.
-`;
-
-// Web scraping function for product pages
-async function scrapeProductPage(url) {
   try {
     const response = await axios.get(url, {
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Accept-Encoding': 'gzip, deflate, br',
+        'Referer': 'https://www.google.com/'
       },
       timeout: 15000
     });
 
     const $ = cheerio.load(response.data);
 
-    // Extract JSON-LD structured data first, as it's often the most reliable
-    let productJsonLd = null;
-    $('script[type="application/ld+json"]').each((i, el) => {
-      try {
-        const data = JSON.parse($(el).html());
-        if (data['@type'] === 'Product') {
-          productJsonLd = data;
-          return false; // exit loop
-        }
-      } catch (e) { /* ignore */ }
+    // --- Etsy Specific Selectors ---
+    const name = $('h1[data-buy-box-listing-title="true"]').text().trim();
+    const priceString = $('p.wt-text-title-03').first().text().trim();
+    const description = $('div#description-text .wt-text-body-01').text().trim();
+
+    const images = [];
+    $('ul.wt-list-unstyled.wt-position-absolute li img').each((i, el) => {
+      images.push($(el).attr('src'));
     });
 
-    const getText = (selector) => $(selector).first().text().trim();
-    const getAttr = (selector, attr) => $(selector).first().attr(attr);
+    // --- Data Cleanup ---
+    const price = parseFloat(priceString.replace(/[^0-9.]/g, ''));
 
-    const title = productJsonLd?.name || getText('h1') || $('title').text();
-    const description = productJsonLd?.description || getText('#product-description, .product-description, [class*="description"]') || getAttr('meta[name="description"]', 'content');
-
-    let price, comparePrice;
-    if (productJsonLd?.offers) {
-      const offer = Array.isArray(productJsonLd.offers) ? productJsonLd.offers[0] : productJsonLd.offers;
-      price = parseFloat(offer.price);
-    } else {
-        const priceText = getText('[class*="price"], [id*="price"]');
-        const prices = priceText.match(/[\d,.]+/g)?.map(p => parseFloat(p.replace(/,/g, ''))) || [];
-        price = Math.min(...prices);
-        comparePrice = prices.length > 1 ? Math.max(...prices) : undefined;
-    }
-
-    const mainImage = productJsonLd?.image || getAttr('meta[property="og:image"]', 'content');
-    const images = $('img[src*="product"]').map((i, el) => $(el).attr('src')).get();
-    if (mainImage && !images.includes(mainImage)) {
-        images.unshift(mainImage);
-    }
-
-    const brand = productJsonLd?.brand?.name || getText('[class*="brand"]');
-    const sku = productJsonLd?.sku || getText('[class*="sku"], [id*="sku"]');
-
-    const bodyText = $('body').text().substring(0, 5000); // Limit body text for performance
-
-    return {
-      url,
-      title,
-      description,
-      price,
-      comparePrice,
-      images: [...new Set(images)], // Unique images
-      brand,
-      sku,
-      content: `Title: ${title}\nDescription: ${description}\nFull Text: ${bodyText}`,
-      jsonLd: productJsonLd,
+    // --- Constructing the Product Data ---
+    const productData = {
+      name: name || 'N/A',
+      description: description || 'N/A',
+      price: isNaN(price) ? 0 : price,
+      comparePrice: 0, // Etsy doesn't always show compare price clearly
+      category: 'Etsy Product', // Default category
+      subcategory: '',
+      brand: 'Etsy Seller', // Etsy doesn't have a standard brand field
+      image: images.length > 0 ? images[0] : '',
+      images: images,
+      countInStock: 10, // Default value
+      rating: 0,
+      numReviews: 0,
+      specifications: {},
+      tags: [],
+      sku: '',
+      seoTitle: name,
+      seoDescription: description.substring(0, 160),
     };
+
+    return productData;
+
   } catch (error) {
     console.error(`Error scraping ${url}:`, error.message);
-    return { url, error: error.message };
-  }
-}
-
-// Generate product data using OpenAI
-async function generateProductData(scrapedData) {
-  try {
-    const prompt = `${PRODUCT_TEMPLATE}
-
-**Scraped Content from URL:** ${scrapedData.url}
-
-**Extracted Information:**
-- Title: ${scrapedData.title}
-- Description: ${scrapedData.description}
-- Price: ${scrapedData.price}
-- Compare Price: ${scrapedData.comparePrice}
-- Brand: ${scrapedData.brand}
-- SKU: ${scrapedData.sku}
-- Images: ${scrapedData.images.join(', ')}
-- JSON-LD Data: ${JSON.stringify(scrapedData.jsonLd, null, 2)}
-
-**Raw Content for Analysis:**
-${scrapedData.content}
-
-**Instructions:**
-Generate the JSON object based on the provided data.
-`;
-
-    const response = await axios.post(`${OPENAI_API_BASE}/chat/completions`, {
-      model: "gpt-4",
-      messages: [
-        {
-          role: "system",
-          content: "You are an expert data extractor for e-commerce websites. Your task is to return a single, valid JSON object with the product data."
-        },
-        {
-          role: "user",
-          content: prompt
-        }
-      ],
-      max_tokens: 2000,
-      temperature: 0.2,
-      response_format: { type: "json_object" }
-    }, {
-      headers: {
-        'Authorization': `Bearer ${OPENAI_API_KEY}`,
-        'Content-Type': 'application/json'
-      }
-    });
-
-    // The response should be a JSON string, so we parse it.
-    return JSON.parse(response.data.choices[0].message.content);
-  } catch (error) {
-    console.error('Error generating product data:', error.response ? error.response.data : error.message);
-    throw new Error('Failed to generate product data from AI.');
+    // Re-throw a more specific error to be handled by the route
+    if (error.response?.status === 403) {
+      throw new Error('Scraping failed: Etsy is blocking the request (403 Forbidden).');
+    }
+    throw new Error(`Scraping failed: ${error.message}`);
   }
 }
 
@@ -193,18 +98,19 @@ router.post("/generate-product", async (req, res) => {
       created_at: new Date()
     });
 
-    processUrl(taskId, product_url);
+    // Process asynchronously
+    processEtsyUrl(taskId, product_url);
 
     res.json({
       status: "success",
-      message: "Product generation initiated",
+      message: "Product scraping initiated",
       task_id: taskId
     });
   } catch (error) {
-    console.error('Error initiating product generation:', error);
+    console.error('Error initiating product scraping:', error);
     res.status(500).json({
       status: "error",
-      message: "Failed to initiate product generation"
+      message: "Failed to initiate product scraping"
     });
   }
 });
@@ -224,25 +130,17 @@ router.get("/product-status/:taskId", (req, res) => {
   res.json(task);
 });
 
-// Async function to process a single URL
-async function processUrl(taskId, url) {
+// Async function to process a single Etsy URL
+async function processEtsyUrl(taskId, url) {
   const task = tasks.get(taskId);
   if (!task) return;
 
   try {
     task.status = "in_progress";
-    task.progress = "25%";
+    task.progress = "50%"; // No AI step, so we start at 50%
     tasks.set(taskId, task);
 
-    const scrapedData = await scrapeProductPage(url);
-    if (scrapedData.error) {
-      throw new Error(`Scraping failed: ${scrapedData.error}`);
-    }
-
-    task.progress = "50%";
-    tasks.set(taskId, task);
-
-    const productData = await generateProductData(scrapedData);
+    const productData = await scrapeEtsyProductPage(url);
 
     task.status = "completed";
     task.progress = "100%";


### PR DESCRIPTION
This commit refactors the "add product with AI" feature to be a dedicated scraper for Etsy.com product pages, as per revised user requirements. The dependency on OpenAI has been removed.

Key changes:
- The backend product generator is now an Etsy-specific scraper that uses cheerio and hard-coded CSS selectors to extract product data.
- The AI-related code has been removed.
- The scraper now includes enhanced browser headers to reduce the chance of being blocked.
- Frontend error handling has been improved to provide user-friendly messages for specific scraping failures (e.g., non-Etsy URLs, blocked requests).
- Fixes a bug in the frontend polling logic related to TanStack Query v5 `refetchInterval` signature.
- Fixes a UI bug where the loading state was not displayed correctly during polling.