### PR TITLE
feat: Add product by scraping eBay URL

### DIFF
--- a/admin/src/pages/ProductsPage.jsx
+++ b/admin/src/pages/ProductsPage.jsx
@@ -123,10 +123,10 @@ const EnhancedSimpleProductsPage = () => {
         setIsCreateDialogOpen(true);
       } else if (task.status === 'failed') {
         let errorMessage = `AI generation failed: ${task.error}`;
-        if (task.error?.includes('403 Forbidden')) {
-          errorMessage = "Could not get product data. The website is blocking automated requests.";
-        } else if (task.error?.includes('only supports Etsy.com')) {
-          errorMessage = "This scraper currently only supports Etsy.com URLs.";
+        if (task.error?.includes('eBay is blocking the request')) {
+          errorMessage = "Could not get product data. eBay is blocking automated requests.";
+        } else if (task.error?.includes('only supports eBay.com')) {
+          errorMessage = "This scraper currently only supports eBay.com URLs.";
         }
         toast.error(errorMessage);
         setAiTaskId(null);

--- a/backend/routes/productGenerator.js
+++ b/backend/routes/productGenerator.js
@@ -11,35 +11,45 @@ const tasks = new Map();
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const OPENAI_API_BASE = process.env.OPENAI_API_BASE || "https://api.openai.com/v1";
 
-// Web scraping function for Etsy product pages
-async function scrapeEtsyProductPage(url) {
-  if (!url.includes('etsy.com')) {
-    throw new Error('This scraper currently only supports Etsy.com URLs.');
+// Web scraping function for eBay product pages
+async function scrapeEbayProductPage(url) {
+  if (!url.includes('ebay.com')) {
+    throw new Error('This scraper currently only supports eBay.com URLs.');
   }
 
   try {
-    const response = await axios.get(url, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'Referer': 'https://www.google.com/'
-      },
-      timeout: 15000
-    });
+    const headers = {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
+      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+      'Accept-Language': 'en-US,en;q=0.9',
+      'Accept-Encoding': 'gzip, deflate, br',
+      'Referer': 'https://www.google.com/'
+    };
 
+    const response = await axios.get(url, { headers, timeout: 15000 });
     const $ = cheerio.load(response.data);
 
-    // --- Etsy Specific Selectors ---
-    const name = $('h1[data-buy-box-listing-title="true"]').text().trim();
-    const priceString = $('p.wt-text-title-03').first().text().trim();
-    const description = $('div#description-text .wt-text-body-01').text().trim();
+    // --- eBay Specific Selectors ---
+    const name = $('.x-item-title__mainTitle .ux-textspans').text().trim();
+    const priceString = $('.x-price-primary .ux-textspans').first().text().trim();
 
     const images = [];
-    $('ul.wt-list-unstyled.wt-position-absolute li img').each((i, el) => {
-      images.push($(el).attr('src'));
+    $('.ux-image-carousel-item img').each((i, el) => {
+      // Use .attr('data-src') if it exists, otherwise fall back to 'src'
+      const imageUrl = $(el).attr('data-src') || $(el).attr('src');
+      if (imageUrl) {
+        images.push(imageUrl);
+      }
     });
+
+    // --- Description from iframe ---
+    let description = 'N/A';
+    const iframeSrc = $('iframe#desc_ifr').attr('src');
+    if (iframeSrc) {
+      const descResponse = await axios.get(iframeSrc, { headers, timeout: 10000 });
+      const $desc = cheerio.load(descResponse.data);
+      description = $desc('div#ds_div').text().trim();
+    }
 
     // --- Data Cleanup ---
     const price = parseFloat(priceString.replace(/[^0-9.]/g, ''));
@@ -47,20 +57,14 @@ async function scrapeEtsyProductPage(url) {
     // --- Constructing the Product Data ---
     const productData = {
       name: name || 'N/A',
-      description: description || 'N/A',
+      description: description,
       price: isNaN(price) ? 0 : price,
-      comparePrice: 0, // Etsy doesn't always show compare price clearly
-      category: 'Etsy Product', // Default category
-      subcategory: '',
-      brand: 'Etsy Seller', // Etsy doesn't have a standard brand field
+      comparePrice: 0,
+      category: 'eBay Product',
+      brand: 'N/A', // eBay doesn't have a standard brand field
       image: images.length > 0 ? images[0] : '',
       images: images,
-      countInStock: 10, // Default value
-      rating: 0,
-      numReviews: 0,
-      specifications: {},
-      tags: [],
-      sku: '',
+      countInStock: 10,
       seoTitle: name,
       seoDescription: description.substring(0, 160),
     };
@@ -69,9 +73,8 @@ async function scrapeEtsyProductPage(url) {
 
   } catch (error) {
     console.error(`Error scraping ${url}:`, error.message);
-    // Re-throw a more specific error to be handled by the route
     if (error.response?.status === 403) {
-      throw new Error('Scraping failed: Etsy is blocking the request (403 Forbidden).');
+      throw new Error('Scraping failed: eBay is blocking the request (403 Forbidden).');
     }
     throw new Error(`Scraping failed: ${error.message}`);
   }
@@ -99,7 +102,7 @@ router.post("/generate-product", async (req, res) => {
     });
 
     // Process asynchronously
-    processEtsyUrl(taskId, product_url);
+    processEbayUrl(taskId, product_url);
 
     res.json({
       status: "success",
@@ -130,17 +133,17 @@ router.get("/product-status/:taskId", (req, res) => {
   res.json(task);
 });
 
-// Async function to process a single Etsy URL
-async function processEtsyUrl(taskId, url) {
+// Async function to process a single eBay URL
+async function processEbayUrl(taskId, url) {
   const task = tasks.get(taskId);
   if (!task) return;
 
   try {
     task.status = "in_progress";
-    task.progress = "50%"; // No AI step, so we start at 50%
+    task.progress = "50%";
     tasks.set(taskId, task);
 
-    const productData = await scrapeEtsyProductPage(url);
+    const productData = await scrapeEbayProductPage(url);
 
     task.status = "completed";
     task.progress = "100%";


### PR DESCRIPTION
This commit refactors the product generation feature to be a dedicated scraper for eBay.com product pages, replacing the previous Etsy implementation.

This change is based on user feedback after discovering that Etsy's anti-scraping measures were too effective to bypass reliably. The implementation now targets eBay's page structure.

Key changes:
- The backend scraper is now tailored for eBay, with specific CSS selectors to find product information.
- Includes logic to handle descriptions loaded within iframes on eBay pages.
- The URL validation and error messages have been updated to be specific to eBay.
- All previous AI and Etsy-specific code has been removed.